### PR TITLE
Fixed Overwatch URL for global region.

### DIFF
--- a/app/parser/profile.js
+++ b/app/parser/profile.js
@@ -3,7 +3,7 @@ const rp = require('request-promise');
 
 export default function(platform, region, tag, cb) {
 
-  const url = `https://playoverwatch.com/en-us/career/${platform}${region === 'global' ? '/' : ('/' + region + '/')}${tag}`;
+  const url = platform === 'pc' ? `https://playoverwatch.com/en-us/career/${platform}/${region}/${tag}` : `https://playoverwatch.com/en-us/career/${platform}/${tag}`;
 
   rp(url).then((htmlString) => {
 

--- a/app/parser/profile.js
+++ b/app/parser/profile.js
@@ -3,7 +3,7 @@ const rp = require('request-promise');
 
 export default function(platform, region, tag, cb) {
 
-  const url = `https://playoverwatch.com/en-us/career/${platform}/${region}/${tag}`;
+  const url = `https://playoverwatch.com/en-us/career/${platform}${region === 'global' ? '/' : ('/' + region + '/')}${tag}`;
 
   rp(url).then((htmlString) => {
 

--- a/app/parser/stats.js
+++ b/app/parser/stats.js
@@ -3,7 +3,7 @@ const rp = require('request-promise');
 
 export default function(platform, region, tag, cb) {
 
-  const url = `https://playoverwatch.com/en-us/career/${platform}${region === 'global' ? '/' : ('/' + region + '/')}${tag}`;
+  const url = platform === 'pc' ? `https://playoverwatch.com/en-us/career/${platform}/${region}/${tag}` : `https://playoverwatch.com/en-us/career/${platform}/${tag}`;
 
   rp(url).then((htmlString) => {
 

--- a/app/parser/stats.js
+++ b/app/parser/stats.js
@@ -3,7 +3,7 @@ const rp = require('request-promise');
 
 export default function(platform, region, tag, cb) {
 
-  const url = `https://playoverwatch.com/en-us/career/${platform}/${region}/${tag}`;
+  const url = `https://playoverwatch.com/en-us/career/${platform}${region === 'global' ? '/' : ('/' + region + '/')}${tag}`;
 
   rp(url).then((htmlString) => {
 


### PR DESCRIPTION
I detected this while helping a friend of mine who's using this API. He was testing it with his Overwatch info which is:

- Battletag: `RAnjos7`
 _(yeah, it doesn't have that numeric suffix - not sure if that's common or not but it was the first time I've seen it)_
- Region: `global`
- Platform: `xbl`

It happens that making a request to the API using the global region like this:
`http://ow-api.herokuapp.com/profile/xbl/global/RAnjos7` returns `Not Found`.

This is because the API is trying to get the data from `https://playoverwatch.com/en-us/career/xbl/global/RAnjos7` but this is wrong because since the region is `global` it doesn't need to be specified, meaning it should be getting the data from `https://playoverwatch.com/en-us/career/xbl/RAnjos7` instead.

So, I'm not sure how you'd fix this, I'm not really into your coding style or into this API's code at all, but this is what I did to keep the one liner. I guess you could mess with the routes or something to make it similar to the official Overwatch page but I thought that would probably be too much change for such a simple issue. I don't think I need to explain my change. :sweat_smile:

<hr>

_Also, I noticed you have code for Quickplay losses and such but I don't see such data on the Overwatch page, is it present in some players or something or is it just outdated?_