### PR TITLE
add test for profile and stats parser

### DIFF
--- a/test/parser/profile.js
+++ b/test/parser/profile.js
@@ -1,0 +1,42 @@
+import test from 'ava';
+import parseProfile from '../../app/parser/profile';
+
+const platform = 'pc'
+const region = 'us'
+const tag = 'Alf-1608'
+
+var result;
+
+test.before.cb(t => {
+  parseProfile(platform, region, tag, (json) => {
+    result = json;
+    t.end();
+  })
+});
+
+test('get base information of user profile', t => {
+  t.deepEqual(typeof(result.username), 'string');
+  t.deepEqual(typeof(result.level), 'number');
+  t.deepEqual(result.portrait.startsWith('http'), true);
+  t.deepEqual(result.levelFrame.startsWith('http'), true);
+  t.deepEqual(result.star.startsWith('http'), true);
+});
+
+test('get information of games played by user', t => {
+  t.deepEqual(typeof(result.games.quickplay.won), 'number');
+
+  t.deepEqual(typeof(result.games.competitive.won), 'number');
+  t.deepEqual(typeof(result.games.competitive.lost), 'number');
+  t.deepEqual(typeof(result.games.competitive.draw), 'number');
+  t.deepEqual(typeof(result.games.competitive.played), 'number');
+});
+
+test('get information of user playtime', t => {
+  t.deepEqual(typeof(result.playtime.quickplay), 'string');
+  t.deepEqual(typeof(result.playtime.competitive), 'string');
+});
+
+test('get information of user competitive stats', t => {
+  t.deepEqual(typeof(result.competitive.rank), 'number');
+  t.deepEqual(result.competitive.rank_img.startsWith('http'), true);
+});

--- a/test/parser/stats.js
+++ b/test/parser/stats.js
@@ -1,0 +1,35 @@
+import test from 'ava';
+import parseStats from '../../app/parser/stats';
+
+const platform = 'pc'
+const region = 'us'
+const tag = 'Alf-1608'
+
+var result;
+
+test.before.cb(t => {
+  parseStats(platform, region, tag, (json) => {
+    result = json;
+    t.end();
+  })
+});
+
+test('get base information of user profile', t => {
+  t.deepEqual(typeof(result.username), 'string');
+  t.deepEqual(typeof(result.level), 'number');
+  t.deepEqual(result.portrait.startsWith('http'), true);
+});
+
+test('get user top heroes information', t => {
+  result['stats']['top_heroes']['quickplay'].map((hero) => {
+    t.deepEqual(typeof(hero['hero']), 'string');
+    t.deepEqual(typeof(hero['played']), 'string');
+    t.deepEqual(hero.img.startsWith('http'), true);
+  });
+
+  result['stats']['top_heroes']['competitive'].map((hero) => {
+    t.deepEqual(typeof(hero['hero']), 'string');
+    t.deepEqual(typeof(hero['played']), 'string');
+    t.deepEqual(hero.img.startsWith('http'), true);
+  });
+});


### PR DESCRIPTION
First try for creating tests for profile and stats parser. Fixes https://github.com/alfg/overwatch-api/issues/26. Apologies for the quality of the code, not really familiar with javascript.

I haven't added the rest of the attributes in stats (like 'combat', 'death', 'match awards') because the value looks empty (http://ow-api.herokuapp.com/stats/pc/us/Alf-1608).

What do you think @alfg? Thanks :)