### PR TITLE
Allow for newer versions of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Overwatch API",
   "main": "index.js",
   "engines": {
-    "node": "6.11.1"
+    "node": ">=6.11.1"
   },
   "dependencies": {
     "babel-register": "^6.26.0",


### PR DESCRIPTION
Ensures `yarn` doesn't complain about installing this package with a newer version of node.