### PR TITLE
Fix endorsements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
     "globals": {
         "require": true,
         "module": true,
-        "Buffer": true
+        "Buffer": true,
+        "exports": true
     },
     "parserOptions": {
         "ecmaVersion": 6,

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overwatch-api",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "An Unoffical Overwatch API.",
   "main": "lib/index.js",
   "engines": {

--- a/api/src/parser/profile.js
+++ b/api/src/parser/profile.js
@@ -31,20 +31,15 @@ export default function(platform, region, tag, cb) {
     // Endorsements.
     const endorsementLevel = $('.masthead .endorsement-level div').last().text();
     const endorsementFrame = $('.masthead .EndorsementIcon').attr('style').slice(21, -1);
-    const sportsmanshipTotal = $('.masthead .EndorsementIcon-border--sportsmanship').data('total');
+
     const sportsmanshipValue = $('.masthead .EndorsementIcon-border--sportsmanship').data('value');
-
-    const shotcallerTotal = $('.masthead .EndorsementIcon-border--shotcaller').data('total');
     const shotcallerValue = $('.masthead .EndorsementIcon-border--shotcaller').data('value');
-
-    const teammateTotal = $('.masthead .EndorsementIcon-border--teammate').data('total');
     const teammateValue = $('.masthead .EndorsementIcon-border--teammate').data('value');
 
     const endorsement = {
-      sportsmanship: { value: sportsmanshipValue, rate: parseFloat((sportsmanshipValue / sportsmanshipTotal * 100).toFixed(2)) },
-      shotcaller: { value: shotcallerValue, rate: parseFloat((shotcallerValue / shotcallerTotal * 100).toFixed(2)) },
-      teammate: { value: teammateValue, rate: parseFloat((teammateValue / teammateTotal * 100).toFixed(2)) },
-      points: sportsmanshipTotal,
+      sportsmanship: { value: sportsmanshipValue, rate: parseFloat((sportsmanshipValue * 100).toFixed(2)) },
+      shotcaller: { value: shotcallerValue, rate: parseFloat((shotcallerValue * 100).toFixed(2)) },
+      teammate: { value: teammateValue, rate: parseFloat((teammateValue * 100).toFixed(2)) },
       level: parseInt(endorsementLevel),
       frame: endorsementFrame,
     };

--- a/api/src/parser/stats.js
+++ b/api/src/parser/stats.js
@@ -31,20 +31,15 @@ export default function(platform, region, tag, cb) {
     // Endorsements.
     const endorsementLevel = $('.masthead .endorsement-level div').last().text();
     const endorsementFrame = $('.masthead .EndorsementIcon').attr('style').slice(21, -1);
-    const sportsmanshipTotal = $('.masthead .EndorsementIcon-border--sportsmanship').data('total');
+
     const sportsmanshipValue = $('.masthead .EndorsementIcon-border--sportsmanship').data('value');
-
-    const shotcallerTotal = $('.masthead .EndorsementIcon-border--shotcaller').data('total');
     const shotcallerValue = $('.masthead .EndorsementIcon-border--shotcaller').data('value');
-
-    const teammateTotal = $('.masthead .EndorsementIcon-border--teammate').data('total');
     const teammateValue = $('.masthead .EndorsementIcon-border--teammate').data('value');
 
     const endorsement = {
-      sportsmanship: { value: sportsmanshipValue, rate: parseFloat((sportsmanshipValue / sportsmanshipTotal * 100).toFixed(2)) },
-      shotcaller: { value: shotcallerValue, rate: parseFloat((shotcallerValue / shotcallerTotal * 100).toFixed(2)) },
-      teammate: { value: teammateValue, rate: parseFloat((teammateValue / teammateTotal * 100).toFixed(2)) },
-      points: sportsmanshipTotal,
+      sportsmanship: { value: sportsmanshipValue, rate: parseFloat((sportsmanshipValue * 100).toFixed(2)) },
+      shotcaller: { value: shotcallerValue, rate: parseFloat((shotcallerValue * 100).toFixed(2)) },
+      teammate: { value: teammateValue, rate: parseFloat((teammateValue * 100).toFixed(2)) },
       level: parseInt(endorsementLevel),
       frame: endorsementFrame,
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overwatch-api-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "An Unoffical Overwatch HTTP API",
   "main": "server/index.js",
   "engines": {


### PR DESCRIPTION
Blizzard removed the `data-total` value from the SVGs which displayed the total points for each endorsement. Since this is no longer available, we just use the new `data-value` to get the value and percentage and for building the endorsement svg.