### PR TITLE
Clean up old unused getPlatforms code and test.

### DIFF
--- a/api/src/parser/utils.js
+++ b/api/src/parser/utils.js
@@ -101,19 +101,3 @@ export function getPrestigeStars(val) {
     }
     return 0;
 }
-
-// No longer used.
-// We now use utils.getPrestigeLevel and utils.getPrestigeStars.
-export function getPlatforms(id, callback) {
-  const url = `https://playoverwatch.com/en-us/career/platforms/${id}`;
-
-  const options = {
-    uri: encodeURI(url),
-    encoding: 'utf8',
-    json: true,
-  }
-
-  rp(options).then((json) => {
-    callback(null, json[0]);
-  });
-}

--- a/api/src/parser/utils.js
+++ b/api/src/parser/utils.js
@@ -1,5 +1,3 @@
-import rp from 'request-promise';
-
 // Credit to @relaera on https://github.com/Fuyukai/OWAPI/pull/270 for this data.
 const prestigeLevels = {
   "1055f5ae3a84b7bd8afa9fcbd2baaf9a412c63e8fe5411025b3264db12927771": 0,  // Bronze Lv 1

--- a/api/test/parser/utils.js
+++ b/api/test/parser/utils.js
@@ -1,18 +1,5 @@
 import test from 'ava';
-import { getPrestigeLevel, getPlatforms } from '../../src/parser/utils';
-
-
-const id = '50284944'; // xQc#11273
-var result;
-
-test.before.cb(t => {
-  getPlatforms(id, (err, json) => {
-    if (err) t.fail();
-
-    result = json;
-    t.end();
-  });
-});
+import { getPrestigeLevel } from '../../src/parser/utils';
 
 test('get the prestige level 0', t => {
     const code = "0x0250000000000918";
@@ -48,10 +35,3 @@ test('get the prestige level default if given a bad value', t => {
 
     t.deepEqual(level, 0);
 });
-
-test('get prestige level using getPlatforms', t => {
-    t.deepEqual(typeof(result.id), 'number');
-    t.deepEqual(typeof(result.playerLevel), 'number');
-    t.deepEqual(result.name, 'xQc#11273');
-});
-


### PR DESCRIPTION
This was my older method of getting prestige level by using an undocumented endpoint:
https://playoverwatch.com/en-us/career/platforms/50284944

Which used to return prestige level info. But now we have a mapping of `prestigeLevels` and `prestigeStars` in `parser/utils.js`.